### PR TITLE
[CIRCLE-11749] Vault 0.10.0 with the v2 key-value API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM vault:0.7.3
+FROM vault:0.10.0
 
 RUN apk add --update python
 

--- a/vault/docker-entrypoint.sh
+++ b/vault/docker-entrypoint.sh
@@ -49,6 +49,7 @@ bootstrap() {
 
   unseal;
 
+  vault kv enable-versioning secret/
   vault secrets enable transit
 }
 

--- a/vault/docker-entrypoint.sh
+++ b/vault/docker-entrypoint.sh
@@ -9,12 +9,12 @@ status() {
 
 wait() {
   NUM_TRIES=0
-  while [[ $NUM_TRIES -lt 5 ]]; do
+  while [ $NUM_TRIES -lt 5 ]; do
     if status | grep -v 'connection refused'; then
-      let NUM_TRIES=5
+      NUM_TRIES=5
       echo vault ready;
     else
-      let NUM_TRIES+=1
+      NUM_TRIES=$((NUM_TRIES + 1))
       sleep 2
     fi
   done
@@ -25,20 +25,20 @@ wait() {
 }
 
 setup_token() {
-  root_token=`grep 'Root' /vault/file/vault-init-out | sed 's/^.*: //g'`
+  root_token=$(grep 'Root' /vault/file/vault-init-out | sed 's/^.*: //g')
 
-  vault login $root_token;
+  vault login "$root_token"
 
-  # period of 100 days
+  # period of 32 days which is the maximum permitted
   vault token create -period="768h" > /vault/file/client-token;
   grep -e 'token ' /vault/file/client-token | sed 's/^token\W*//g' > /vault/__restricted/client-token;
 }
 
 unseal() {
-  keys=`head -n 3 /vault/file/vault-init-out | sed 's/^.*: //g'`
+  keys=$(head -n 3 /vault/file/vault-init-out | sed 's/^.*: //g')
 
   for k in $keys; do
-    vault operator unseal $k;
+    vault operator unseal "$k";
   done;
 
   setup_token;
@@ -64,7 +64,7 @@ child_process () {
 }
 
 vault_server() {
-  if [[ "skip" = "$SKIP_SETCAP" ]]; then
+  if [ "skip" = "${SKIP_SETCAP:-}" ]; then
     sed -i 's/false/true/g' /vault/config/vault.json;
   fi;
   vault server -config=/vault/config/;

--- a/vault/docker-entrypoint.sh
+++ b/vault/docker-entrypoint.sh
@@ -27,10 +27,10 @@ wait() {
 setup_token() {
   root_token=`grep 'Root' /vault/file/vault-init-out | sed 's/^.*: //g'`
 
-  vault auth $root_token;
+  vault login $root_token;
 
   # period of 100 days
-  vault token-create -period="2400h" > /vault/file/client-token;
+  vault token create -period="768h" > /vault/file/client-token;
   grep -e 'token ' /vault/file/client-token | sed 's/^token\W*//g' > /vault/__restricted/client-token;
 }
 
@@ -38,18 +38,18 @@ unseal() {
   keys=`head -n 3 /vault/file/vault-init-out | sed 's/^.*: //g'`
 
   for k in $keys; do
-    vault unseal $k;
+    vault operator unseal $k;
   done;
 
   setup_token;
 }
 
 bootstrap() {
-  vault init > /vault/file/vault-init-out 2>&1
+  vault operator init > /vault/file/vault-init-out 2>&1
 
   unseal;
 
-  vault mount transit;
+  vault secrets enable transit
 }
 
 child_process () {


### PR DESCRIPTION
- Upgrade to Vault 0.10.0.
- Migrate the key-value store to API v2
- Clean up the entrypoint script a little bit.