### PR TITLE
Added the 2.x branches to cci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,4 +48,6 @@ workflows:
             - build
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - /server-2.*/


### PR DESCRIPTION
Part of the 2.17 vuln patching in libressl.  Adding the updates to cci config to also process those branches.