### PR TITLE
Updated vault base image to 1.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM vault:0.10.0
+FROM vault:1.1.2
 
-RUN apk add --update python libressl
+RUN apk add --update python
 
 ADD ./vault/ /vault
 WORKDIR /vault


### PR DESCRIPTION
Alpine 3.7 had libressl pinned to vulnerable version.  New vault uses
Alpine 3.8.  This seemed the more productive way to upgrade.  Local
testing showed no issue with vault 1.1.2