### PR TITLE
removed reference to ununsed /secret

### DIFF
--- a/vault/docker-entrypoint.sh
+++ b/vault/docker-entrypoint.sh
@@ -49,7 +49,6 @@ bootstrap() {
 
   unseal;
 
-  vault kv enable-versioning secret/
   vault secrets enable transit
 }
 


### PR DESCRIPTION
The docker-entrypoint.sh was calling enable-versioning on a secrets
store that was never used and never created. Apparently older versions
would create it and local versions had data with it defined.