### PR TITLE
[SEC-1428] Version bump to vault 1.5 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM vault:1.1.5
+FROM vault:1.5.0
 
-RUN apk add --update python
+RUN apk add --update python sqlite
 
 ADD ./vault/ /vault
 WORKDIR /vault


### PR DESCRIPTION
Take 2.  The previous image still had vulns in sqlite package.  It needed to be updated.